### PR TITLE
Make compatible with gcc 5.0 and fix overly aggressive cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.0)
 
 project(AllocatorBuilder)
 
@@ -12,9 +12,9 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" AND MSVC_VERSION EQUAL 1700)
   add_definitions(-D_VARIADIC_MAX=10)
 endif ()
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GCC")  
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")  
   #set(CMAKE_CXX_FLAGS "-O3 -fsanitize=thread -g -Wall -std=c++11")
-  set(CMAKE_CXX_FLAGS "-O3 -g -Wall -std=c++11")
+  set(CMAKE_CXX_FLAGS "-O3 -g -Wall -std=c++14")
   set(CMAKE_LINK_FLAGS "-pthreads")
 endif()
 
@@ -23,7 +23,7 @@ set(Boost_USE_STATIC_LIBS        OFF)
 set(Boost_USE_MULTITHREADED      ON)
 set(Boost_USE_STATIC_RUNTIME     OFF)
 #set(BOOST_ALL_DYN_LINK           ON) 
-find_package( Boost 1.59.0 REQUIRED COMPONENTS system thread chrono date_time)
+find_package( Boost 1.55.0 REQUIRED COMPONENTS system thread chrono date_time)
 
 
 add_subdirectory(util/gtest-1.7.0)

--- a/alb/freelist.hpp
+++ b/alb/freelist.hpp
@@ -141,8 +141,8 @@ namespace alb {
      */
     block allocate(size_t n)
     {
-      BOOST_ASSERT_MSG(_lowerBound.value() != -1, "The lower bound was not initialized!");
-      BOOST_ASSERT_MSG(_upperBound.value() != -1, "The upper bound was not initialized!");
+      BOOST_ASSERT_MSG(_lowerBound.value() != ::std::numeric_limits<size_t>::max(), "The lower bound was not initialized!");
+      BOOST_ASSERT_MSG(_upperBound.value() != ::std::numeric_limits<size_t>::max(), "The upper bound was not initialized!");
 
       if (_lowerBound.value() <= n && n <= _upperBound.value()) {
         void *freeBlock = nullptr;

--- a/test/BucketizerTest.cpp
+++ b/test/BucketizerTest.cpp
@@ -27,16 +27,16 @@ class BucketizerTest : public AllocatorBaseTest<AllocatorUnderTest> {
 
 TEST_F(BucketizerTest, ThatMinAndMaxSizeOfTheBucketItemsAreSetSpecifiedByTheParameter)
 {
-  ASSERT_EQ(3, AllocatorUnderTest::number_of_buckets);
+  ASSERT_EQ(3u, AllocatorUnderTest::number_of_buckets);
 
-  EXPECT_EQ(17, sut._buckets[0].min_size());
-  EXPECT_EQ(32, sut._buckets[0].max_size());
+  EXPECT_EQ(17u, sut._buckets[0].min_size());
+  EXPECT_EQ(32u, sut._buckets[0].max_size());
 
-  EXPECT_EQ(33, sut._buckets[1].min_size());
-  EXPECT_EQ(48, sut._buckets[1].max_size());
+  EXPECT_EQ(33u, sut._buckets[1].min_size());
+  EXPECT_EQ(48u, sut._buckets[1].max_size());
 
-  EXPECT_EQ(49, sut._buckets[2].min_size());
-  EXPECT_EQ(64, sut._buckets[2].max_size());
+  EXPECT_EQ(49u, sut._buckets[2].min_size());
+  EXPECT_EQ(64u, sut._buckets[2].max_size());
 }
 
 TEST_F(BucketizerTest, ThatAllocatingBeyondTheAllocatorsRangeResultsInAnEmptyBlock)
@@ -86,7 +86,7 @@ TEST_F(BucketizerTest, ThatAReallocationWithInTheEdgesOfABucketItemTheLengthAndT
   auto originalPtr = mem.ptr;
   EXPECT_TRUE(sut.reallocate(mem, 20));
 
-  EXPECT_EQ(32, mem.length);
+  EXPECT_EQ(32u, mem.length);
   EXPECT_EQ(originalPtr, mem.ptr);
 
   EXPECT_MEM_EQ(mem.ptr, (void *)ReferenceData.data(), 32);
@@ -103,7 +103,7 @@ TEST_F(BucketizerTest,
   auto originalPtr = mem.ptr;
   EXPECT_TRUE(sut.reallocate(mem, 33));
 
-  EXPECT_EQ(48, mem.length);
+  EXPECT_EQ(48u, mem.length);
   EXPECT_NE(originalPtr, mem.ptr);
 
   EXPECT_MEM_EQ(mem.ptr, (void *)ReferenceData.data(), 32);
@@ -122,7 +122,7 @@ TEST_F(BucketizerTest, ThatAReallocationOfAnEmptyBlockWithinTheBoundsBytesReturn
 {
   alb::block mem;
   EXPECT_TRUE(sut.reallocate(mem, 32));
-  EXPECT_EQ(32, mem.length);
+  EXPECT_EQ(32u, mem.length);
   deallocateAndCheckBlockIsThenEmpty(mem);
 }
 
@@ -143,7 +143,7 @@ TEST_F(
   auto originalPtr = mem.ptr;
   EXPECT_TRUE(sut.reallocate(mem, 20));
 
-  EXPECT_EQ(32, mem.length);
+  EXPECT_EQ(32u, mem.length);
   EXPECT_NE(originalPtr, mem.ptr);
 
   EXPECT_MEM_EQ(mem.ptr, (void *)ReferenceData.data(), 32);


### PR DESCRIPTION
CMake is a bit overly aggressive with versions, this will work out of the box on Ubuntu latest.
GNU will enforce signed comparisons on -wall, so I fixed those.  